### PR TITLE
モバイルナビバーの UX 改善

### DIFF
--- a/_blog/themes/icarus/include/style/dark.styl
+++ b/_blog/themes/icarus/include/style/dark.styl
@@ -61,7 +61,10 @@ html[data-theme='dark']
             border-color: $dark-link
 
         .navbar-logo img
-            filter: invert(1)
+            filter: brightness(0) invert(1)
+            border: 1.5px solid rgba(255, 255, 255, 0.3)
+            border-radius: 4px
+            padding: 2px
 
     +until($navbar-breakpoint)
         .navbar-main .navbar-menu

--- a/_blog/themes/icarus/include/style/navbar.styl
+++ b/_blog/themes/icarus/include/style/navbar.styl
@@ -42,6 +42,7 @@ $navbar-item-margin-h ?= 0
     +until($navbar-breakpoint)
         .navbar-menu
             box-shadow: 0 8px 16px rgba(10, 10, 10, .1)
+            background-color: #fff
 
             .navbar-item
                 padding: .75rem 1rem
@@ -53,6 +54,14 @@ $navbar-item-margin-h ?= 0
 
             .navbar-end
                 display: none
+
+            // ハンバーガー開放時: コンテンツに被さるオーバーレイ表示
+            &.is-active
+                position: absolute
+                top: 100%
+                left: 0
+                right: 0
+                z-index: 30
 
 // Categories ドロップダウン
 .navbar-categories

--- a/_blog/themes/icarus/layout/common/navbar.jsx
+++ b/_blog/themes/icarus/layout/common/navbar.jsx
@@ -62,6 +62,14 @@ class Navbar extends Component {
                             {translations.map(t => <a class={classname({ 'lang-toggle-option': true, 'is-active': t.active })} href={t.url}>{t.label}</a>)}
                         </div>
                     </div>
+                    {/* スマホ常時表示: ダーク/ライト切り替え + 検索 */}
+                    <a class="navbar-item theme-toggle is-hidden-desktop" title="Toggle dark mode" href="javascript:;" aria-label="Toggle dark mode">
+                        <i class="fas fa-moon theme-toggle-dark"></i>
+                        <i class="fas fa-sun theme-toggle-light"></i>
+                    </a>
+                    {showSearch ? <a class="navbar-item search is-hidden-desktop" title={searchTitle} href="javascript:;">
+                        <i class="fas fa-search"></i>
+                    </a> : null}
                     {/* スマホ用ハンバーガーボタン */}
                     <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbar-menu">
                         <span aria-hidden="true"></span>
@@ -101,15 +109,15 @@ class Navbar extends Component {
                                 {translations.map(t => <a class={classname({ 'lang-toggle-option': true, 'is-active': t.active })} href={t.url}>{t.label}</a>)}
                             </div>
                         </div> : null}
-                        {/* ダーク / ライト切り替えトグル */}
-                        <a class="navbar-item theme-toggle" title="Toggle dark mode" href="javascript:;" aria-label="Toggle dark mode">
+                        {/* ダーク / ライト切り替えトグル（デスクトップ; スマホは navbar-brand に表示） */}
+                        <a class="navbar-item theme-toggle is-hidden-touch" title="Toggle dark mode" href="javascript:;" aria-label="Toggle dark mode">
                             <i class="fas fa-moon theme-toggle-dark"></i>
                             <i class="fas fa-sun theme-toggle-light"></i>
                         </a>
                         {showToc ? <a class="navbar-item is-hidden-tablet catalogue" title={tocTitle} href="javascript:;">
                             <i class="fas fa-list-ul"></i>
                         </a> : null}
-                        {showSearch ? <a class="navbar-item search" title={searchTitle} href="javascript:;">
+                        {showSearch ? <a class="navbar-item search is-hidden-touch" title={searchTitle} href="javascript:;">
                             <i class="fas fa-search"></i>
                         </a> : null}
                     </div>


### PR DESCRIPTION
- ダークモードのロゴを brightness(0) invert(1) で白化し枠線を追加
- ハンバーガーメニューを記事にオーバーレイ表示（position: absolute）
- ダークモード切り替え・検索アイコンをスマホでも常時ヘッダーに表示