### PR TITLE
PC版目次ウィジェットを右カラムから左カラムへ移動

### DIFF
--- a/_blog/_config.icarus.yml
+++ b/_blog/_config.icarus.yml
@@ -107,7 +107,7 @@ widgets:
   #     RSS:
   #       icon: fas fa-rss
   #       url: /atom.xml
-  - position: right
+  - position: left
     type: toc
     index: true
     collapsed: false


### PR DESCRIPTION
## Summary

- `_config.icarus.yml` の TOC ウィジェットの `position` を `right` → `left` に変更
- PC版（tablet以上）の記事詳細で目次が左サイドバーに全項目表示されるようになる
- SP版のナビバー内目次ボタン（`is-hidden-tablet`）は引き続き mobile のみ表示

## Test plan

- [ ] PC版記事詳細で目次が左側に表示されることを確認
- [ ] 目次の全見出し（h1〜h3）が展開表示されることを確認
- [ ] SP版で左サイドバーが表示されず、ナビバーボタンが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)