### PR TITLE
PC版記事詳細ページのナビバー・カテゴリーバーのスティッキーを解除

### DIFF
--- a/_blog/themes/icarus/include/style/navbar.styl
+++ b/_blog/themes/icarus/include/style/navbar.styl
@@ -172,6 +172,14 @@ html[data-theme='dark']
         z-index: 29
         background-color: $scheme-main
 
+// PC版記事詳細ページ: ナビバー・カテゴリーバーのスティッキーを解除
+body.page-post
+    +from($navbar-breakpoint)
+        .navbar-main
+            position: static
+        .category-bar
+            position: static
+
     .category-bar-inner
         display: flex
         flex-wrap: wrap


### PR DESCRIPTION
## Summary

- PC幅で `body.page-post` に対し `.navbar-main` と `.category-bar` の `position` を `static` に上書き
- SP版・一覧ページには影響なし

## Test plan

- [ ] PC幅で記事詳細ページを開き、スクロール時にナビバー・カテゴリーバーが固定されないことを確認
- [ ] SP幅で記事詳細ページを開き、動作が変わっていないことを確認
- [ ] 一覧ページ（PC幅）でナビバー・カテゴリーバーのスティッキーが維持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)